### PR TITLE
ci: update lint commit

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
 
       - name: Check commits
-        uses: wagoid/commitlint-github-action@v4
+        uses: wagoid/commitlint-github-action@v5
 
   lint-markdown:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
- Don't lint commit messages if dependabot
- [ci: bumps wagoid/commitlint-github-action from 4 to 5](https://github.com/okp4/wiki/pull/4/commits/75f26e9fbf72ae90fb98e9116850f3ee34f7345f)